### PR TITLE
Return Floating Licenses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,5 @@
 
 # Files required for the action
 !entrypoint.sh
+!services-config.json.template
 !action.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ LABEL "homepage"="http://github.com/webbertakken/unity-actions"
 LABEL "maintainer"="Webber Takken <webber@takken.io>"
 
 ADD entrypoint.sh /entrypoint.sh
+ADD services-config.json.template /services-config.json.template
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# FROM unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
-FROM docker.artifactory.build.k8s.pelotime.com/unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
+FROM unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
+# FROM docker.artifactory.build.k8s.pelotime.com/unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
 
 LABEL "com.github.actions.name"="Unity - Return License"
 LABEL "com.github.actions.description"="Return a Unity Pro license and free up a spot towards the maximum number of active licenses."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
+# FROM unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
+FROM docker.artifactory.build.k8s.pelotime.com/unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
 
 LABEL "com.github.actions.name"="Unity - Return License"
 LABEL "com.github.actions.description"="Return a Unity Pro license and free up a spot towards the maximum number of active licenses."

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ LABEL "maintainer"="Webber Takken <webber@takken.io>"
 ADD entrypoint.sh /entrypoint.sh
 COPY services-config.json.template /services-config.json.template
 RUN chmod +x /entrypoint.sh
-RUN chmod 644 /services-config.json.template
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
-# FROM docker.artifactory.build.k8s.pelotime.com/unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
 
 LABEL "com.github.actions.name"="Unity - Return License"
 LABEL "com.github.actions.description"="Return a Unity Pro license and free up a spot towards the maximum number of active licenses."
@@ -11,6 +10,7 @@ LABEL "homepage"="http://github.com/webbertakken/unity-actions"
 LABEL "maintainer"="Webber Takken <webber@takken.io>"
 
 ADD entrypoint.sh /entrypoint.sh
-ADD services-config.json.template /services-config.json.template
+COPY services-config.json.template /services-config.json.template
 RUN chmod +x /entrypoint.sh
+RUN chmod 644 /services-config.json.template
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM unityci/editor:ubuntu-2019.2.11f1-base-1
+FROM unityci/editor:ubuntu-6000.0.21f1-base-3.1.0
 
 LABEL "com.github.actions.name"="Unity - Return License"
 LABEL "com.github.actions.description"="Return a Unity Pro license and free up a spot towards the maximum number of active licenses."

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,17 @@
 name: 'Unity - Return License'
 author: Webber Takken <webber@takken.io>
 description: 'Return a Unity Pro license and free up a spot towards the maximum number of active licenses.'
-inputs: {}
+inputs:
+  unityLicensingServer:
+    default: ''
+    required: false
+    description: 'The Unity licensing server address to use for activating Unity.'
 outputs: {}
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.unityLicensingServer }}
 branding:
   icon: 'box'
   color: 'gray-dark'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,6 @@ printenv
 
 UNITY_LICENSING_SERVER=$1
 
-touch license.txt
-
 echo "Unity Licensing Server: $UNITY_LICENSING_SERVER"
 if [[ -n "$UNITY_SERIAL" ]]; then
   #
@@ -36,7 +34,7 @@ elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
   echo "Before:"
   cat services-config.json.template | jq
   mkdir -p /usr/share/unity3d/config
-  sed "s|%URL%|$UNITY_LICENSING_SERVER|g" services-config.json.template > /usr/share/unity3d/config/services-config.json
+  sed "s|%URL%|$UNITY_LICENSING_SERVER|g" /services-config.json.template > /usr/share/unity3d/config/services-config.json
   echo "After:"
   cat /usr/share/unity3d/config/services-config.json | jq
   echo "Returning floating license: \"$FLOATING_LICENSE_ID\""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,9 @@ echo "Files: $(ls)"
 echo "Environment Variables:"
 printenv
 
+UNITY_LICENSING_SERVER=$1
+
+echo "Unity Licensing Server: $UNITY_LICENSING_SERVER"
 if [[ -n "$UNITY_SERIAL" ]]; then
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
@@ -17,27 +20,22 @@ if [[ -n "$UNITY_SERIAL" ]]; then
     -logFile /dev/stdout \
     -quit \
     -returnlicense
-elif [[ -n "$FLOATING_LICENSE" ]]; then
-  #
-  # FLOATING LICENSE MODE
-  #
-  # This will return the license that is currently in use.
-  #
-  echo "Returning floating license: \"$FLOATING_LICENSE\""
-  /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE"
-
-elif [[ -f "license.txt" ]]; then
-  echo "Found license.txt file. Parsing file for floating license."
-  PARSEDFILE=$(grep -oP '\".*?\"' < license.txt | tr -d '"')
-  FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
-
+elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
   #
   # FLOATING LICENSE FILE MODE
   #
   # This will return the license that is currently in use.
   #
+  echo "Found license.txt file. Parsing file for floating license."
+  PARSEDFILE=$(grep -oP '\".*?\"' < license.txt | tr -d '"')
+  FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
+
+  echo "Updating services-config.json to use $UNITY_LICENSING_SERVER"
+  sed 's/%URL%/test/g' services-config.json.template > /usr/share/unity3d/config/services-config.json
+
+  echo "Configuring services-config.json"
   echo "Returning floating license: \"$FLOATING_LICENSE_ID\""
   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE_ID"
 else
-  echo "No UNITY_SERIAL detected! No license was returned."
+  echo "No license was returned."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,11 @@ elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
   FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
 
   echo "Updating services-config.json to use $UNITY_LICENSING_SERVER"
+  echo "Looking in /usr/share: $(ls /usr/share)"
+  echo "Looking in /usr/share/unity3d: $(ls /usr/share/unity3d)"
+  echo "Looking in /usr/share/unity3d/config: $(ls /usr/share/unity3d/config)"
+
+  mkdir -p /usr/share/unity3d/config
   sed 's/%URL%/test/g' services-config.json.template > /usr/share/unity3d/config/services-config.json
 
   echo "Configuring services-config.json"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+echo "Entrypoint script started."
+echo "Current directory:"
+pwd
+echo "Files: $(ls -la)"
+echo "Environment Variables:"
+printenv
+
 if [[ -n "$UNITY_SERIAL" ]]; then
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,51 @@ if [[ -n "$UNITY_SERIAL" ]]; then
     -logFile /dev/stdout \
     -quit \
     -returnlicense
+elif [[ -n "$FLOATING_LICENSE"]]; then
+  #
+  # FLOATING LICENSE MODE
+  #
+  # This will return the license that is currently in use.
+  #
+  echo "Returning floating license: \"$FLOATING_LICENSE\""
+  /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE"
+
+elif [[ -f "license.txt" ]]; then
+  echo "Found license.txt file. Parsing file for floating license."
+  PARSEDFILE=$(grep -oP '\".*?\"' < license.txt | tr -d '"')
+  FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
+
+  #
+  # FLOATING LICENSE FILE MODE
+  #
+  # This will return the license that is currently in use.
+  #
+  echo "Returning floating license: \"$FLOATING_LICENSE_ID\""
+  /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE_ID"
 else
   echo "No UNITY_SERIAL detected! No license was returned."
 fi
+
+
+# #!/usr/bin/env bash
+
+# if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
+#   #
+#   # Return any floating license used.
+#   #
+#   echo "Returning floating license: \"$FLOATING_LICENSE\""
+#   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE"
+# elif [[ -n "$UNITY_SERIAL" ]]; then
+#   #
+#   # SERIAL LICENSE MODE
+#   #
+#   # This will return the license that is currently in use.
+#   #
+#   unity-editor \
+#     -logFile /dev/stdout \
+#     -quit \
+#     -returnlicense \
+#     -username "$UNITY_EMAIL" \
+#     -password "$UNITY_PASSWORD" \
+#     -projectPath "/BlankProject"
+# fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,7 @@
 #!/usr/bin/env bash
 
-echo "Entrypoint script started."
-echo "Current directory:"
-pwd
-echo "Files: $(ls)"
-echo "Environment Variables:"
-printenv
-
 UNITY_LICENSING_SERVER=$1
 
-echo "Unity Licensing Server: $UNITY_LICENSING_SERVER"
 if [[ -n "$UNITY_SERIAL" ]]; then
   #
   # PROFESSIONAL (SERIAL) LICENSE MODE
@@ -24,19 +16,17 @@ elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
   #
   # FLOATING LICENSE FILE MODE
   #
-  # This will return the license that is currently in use.
+  # This will return the floating license that is currently in use. 
+  # This depends on a licensing server URL and a license file being present
   #
-  echo "Found license.txt file. Parsing file for floating license."
+  # https://github.com/game-ci/unity-builder/blob/main/dist/platforms/ubuntu/steps/activate.sh#L70-L71
   PARSEDFILE=$(grep -oP '\".*?\"' < license.txt | tr -d '"')
   FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
 
-  echo "Updating services-config.json to use $UNITY_LICENSING_SERVER"
-  echo "Before:"
-  cat services-config.json.template | jq
   mkdir -p /usr/share/unity3d/config
   sed "s|%URL%|$UNITY_LICENSING_SERVER|g" /services-config.json.template > /usr/share/unity3d/config/services-config.json
-  echo "After:"
-  cat /usr/share/unity3d/config/services-config.json | jq
+
+  # https://github.com/game-ci/unity-builder/blob/main/dist/platforms/ubuntu/steps/return_license.sh#L8
   echo "Returning floating license: \"$FLOATING_LICENSE_ID\""
   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE_ID"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,14 +31,9 @@ elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
   FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
 
   echo "Updating services-config.json to use $UNITY_LICENSING_SERVER"
-  echo "Looking in /usr/share: $(ls /usr/share)"
-  echo "Looking in /usr/share/unity3d: $(ls /usr/share/unity3d)"
-  echo "Looking in /usr/share/unity3d/config: $(ls /usr/share/unity3d/config)"
-
   mkdir -p /usr/share/unity3d/config
-  sed 's/%URL%/test/g' services-config.json.template > /usr/share/unity3d/config/services-config.json
+  sed "s/%URL%/$UNITY_LICENSING_SERVER/g" services-config.json.template > /usr/share/unity3d/config/services-config.json
 
-  echo "Configuring services-config.json"
   echo "Returning floating license: \"$FLOATING_LICENSE_ID\""
   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE_ID"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,8 @@ printenv
 
 UNITY_LICENSING_SERVER=$1
 
+touch license.txt
+
 echo "Unity Licensing Server: $UNITY_LICENSING_SERVER"
 if [[ -n "$UNITY_SERIAL" ]]; then
   #
@@ -31,10 +33,12 @@ elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
   FLOATING_LICENSE_ID=$(sed -n 2p <<< "$PARSEDFILE")
 
   echo "Updating services-config.json to use $UNITY_LICENSING_SERVER"
+  echo "Before:"
+  cat services-config.json.template | jq
   mkdir -p /usr/share/unity3d/config
   sed "s|%URL%|$UNITY_LICENSING_SERVER|g" services-config.json.template > /usr/share/unity3d/config/services-config.json
-  echo: "services-config.json: $(cat /usr/share/unity3d/config/services-config.json)"
-
+  echo "After:"
+  cat /usr/share/unity3d/config/services-config.json | jq
   echo "Returning floating license: \"$FLOATING_LICENSE_ID\""
   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE_ID"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 echo "Entrypoint script started."
 echo "Current directory:"
 pwd
-echo "Files: $(ls -la)"
+echo "Files: $(ls)"
 echo "Environment Variables:"
 printenv
 
@@ -17,7 +17,7 @@ if [[ -n "$UNITY_SERIAL" ]]; then
     -logFile /dev/stdout \
     -quit \
     -returnlicense
-elif [[ -n "$FLOATING_LICENSE"]]; then
+elif [[ -n "$FLOATING_LICENSE" ]]; then
   #
   # FLOATING LICENSE MODE
   #
@@ -41,27 +41,3 @@ elif [[ -f "license.txt" ]]; then
 else
   echo "No UNITY_SERIAL detected! No license was returned."
 fi
-
-
-# #!/usr/bin/env bash
-
-# if [[ -n "$UNITY_LICENSING_SERVER" ]]; then
-#   #
-#   # Return any floating license used.
-#   #
-#   echo "Returning floating license: \"$FLOATING_LICENSE\""
-#   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE"
-# elif [[ -n "$UNITY_SERIAL" ]]; then
-#   #
-#   # SERIAL LICENSE MODE
-#   #
-#   # This will return the license that is currently in use.
-#   #
-#   unity-editor \
-#     -logFile /dev/stdout \
-#     -quit \
-#     -returnlicense \
-#     -username "$UNITY_EMAIL" \
-#     -password "$UNITY_PASSWORD" \
-#     -projectPath "/BlankProject"
-# fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,8 @@ elif [[ -n "$UNITY_LICENSING_SERVER" && -f "license.txt" ]]; then
 
   echo "Updating services-config.json to use $UNITY_LICENSING_SERVER"
   mkdir -p /usr/share/unity3d/config
-  sed "s/%URL%/$UNITY_LICENSING_SERVER/g" services-config.json.template > /usr/share/unity3d/config/services-config.json
+  sed "s|%URL%|$UNITY_LICENSING_SERVER|g" services-config.json.template > /usr/share/unity3d/config/services-config.json
+  echo: "services-config.json: $(cat /usr/share/unity3d/config/services-config.json)"
 
   echo "Returning floating license: \"$FLOATING_LICENSE_ID\""
   /opt/unity/Editor/Data/Resources/Licensing/Client/Unity.Licensing.Client --return-floating "$FLOATING_LICENSE_ID"

--- a/services-config.json.template
+++ b/services-config.json.template
@@ -1,0 +1,7 @@
+{
+  "licensingServiceBaseUrl": "%URL%",
+  "enableEntitlementLicensing": true,
+  "enableFloatingApi": true,
+  "clientConnectTimeoutSec": 5,
+  "clientHandshakeTimeoutSec": 10,
+}

--- a/services-config.json.template
+++ b/services-config.json.template
@@ -3,5 +3,5 @@
   "enableEntitlementLicensing": true,
   "enableFloatingApi": true,
   "clientConnectTimeoutSec": 5,
-  "clientHandshakeTimeoutSec": 10,
+  "clientHandshakeTimeoutSec": 10
 }


### PR DESCRIPTION
#### Changes

- updates base image used in Dockerfile
- adds input `unityLicensingServer`
- when `license.txt` is present in current workspace (from activation step in [unity-builder](https://github.com/game-ci/unity-builder/blob/main/dist/platforms/ubuntu/steps/activate.sh#L70) and [unity-test-runner](https://github.com/game-ci/unity-test-runner/blob/main/dist/platforms/ubuntu/activate.sh#L61)) and `unityLicensingServer` is set, configure editor with licensing server and return the floating license

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
- [ ] Tests (added, updated or not needed)
